### PR TITLE
Block the SLC format by SCFM

### DIFF
--- a/source/main.c
+++ b/source/main.c
@@ -22,11 +22,14 @@ void kern_main()
     debug_printf("init_linking symbol at: %08x\n", wafel_find_symbol("init_linking"));
 
     // Patch IOS-FS thing
-    ASM_PATCH_K(0x1072272C, "mvn r5, #0x8000")
+    ASM_PATCH_K(0x1072272C, "mvn r5, #0x8000");
 
     // block system updates by overwriting url
     U32_PATCH_K(0xe22830e0, 0);
     U32_PATCH_K(0xe22b2a78, 0);
+
+    // patch out the format with an endless loop
+    BRANCH_PATCH_K(0x107e8178,0x107e8178)
 
     debug_printf("isfshax patch applied\n");
 }

--- a/source/main.c
+++ b/source/main.c
@@ -28,8 +28,8 @@ void kern_main()
     U32_PATCH_K(0xe22830e0, 0);
     U32_PATCH_K(0xe22b2a78, 0);
 
-    // patch out the format with an endless loop
-    BRANCH_PATCH_K(0x107e8178,0x107e8178)
+    // patch out the format with an undefined instruction (crash)
+    U32_PATCH_K(0x107e8178,0xFFFFFFFF);
 
     debug_printf("isfshax patch applied\n");
 }


### PR DESCRIPTION
SCFM formats the SLC if it can't detect an valid isfs. This can happen if the OTP is invalid or doesn't match the SLC. A format would remove ISFShax and brick the console. This patch makes sure, this doesn't happen